### PR TITLE
🎉 Shadow-cljs integration

### DIFF
--- a/src/stylo/core.cljc
+++ b/src/stylo/core.cljc
@@ -44,13 +44,19 @@
        (into [(keyword (str ".c" (hash rules)))] (join-rules rules)))))
 
 
-(defn get-styles []
-  (garden.core/css
+(defn get-styles
+  ([]
+   (get-styles {}))
+  ([flags]
+   (garden.core/css
+    flags
     (concat
-      stylo.tailwind.preflight/preflight
-      (->> @styles
-           (sort-by (comp :location meta val))
+     stylo.tailwind.preflight/preflight
+     (->> @styles
+          (sort-by (comp :location meta val))
+          (map (fn [[k v]] (into [k] v))))))))
            (map (fn [[k v]] (into [k] v)))))))
+
 
 #?(:clj
    (defmacro mount-style

--- a/src/stylo/core.cljc
+++ b/src/stylo/core.cljc
@@ -55,7 +55,17 @@
      (->> @styles
           (sort-by (comp :location meta val))
           (map (fn [[k v]] (into [k] v))))))))
-           (map (fn [[k v]] (into [k] v)))))))
+
+
+(defn get-stylo-styles
+  ([]
+   (get-stylo-styles {}))
+  ([flags]
+   (garden.core/css
+    flags
+    (->> @styles
+         (sort-by (comp :location meta val))
+         (map (fn [[k v]] (into [k] v)))))))
 
 
 #?(:clj

--- a/src/stylo/shadow_cljs.clj
+++ b/src/stylo/shadow_cljs.clj
@@ -1,0 +1,65 @@
+(ns stylo.shadow-cljs
+  (:require [clojure.java.io :as io]
+            [shadow.jvm-log :as log]
+            [stylo.core]))
+
+(def css-path-key ::css-path)
+
+
+(defn get-path [build-state]
+  (get build-state css-path-key))
+
+
+(defn assoc-path [build-state path]
+  (assoc build-state css-path-key path))
+
+
+(defn write!
+  ([css output-dir file-name]
+   (write! css output-dir file-name false))
+  ([css output-dir file-name append]
+   (try
+     (when-not (.exists output-dir)
+       (.mkdirs output-dir))
+     (spit (str output-dir "/" file-name) css :append append)
+     (log/info ::write! (str "Stylo css saved to "  output-dir "/" file-name))
+     (catch Exception e
+       (log/warn ::write! {:message (str "Failed to save Stylo css in "  output-dir "/" file-name)
+                           :exception e})))))
+
+
+(defn hook
+  {:shadow.build/stage :flush}
+  ([build-state]
+   (hook build-state {:output-dir (str "target/" (name (:shadow.build/mode build-state)) "/public/css")
+                      :file-name "stylo.min.css"}))
+  ([build-state options]
+   (let [{:keys [output-dir file-name]} options
+         output-dir (io/file output-dir)]
+     (when (seq @stylo.core/styles)
+       (log/info ::hook (str "Stylo styles: " (keys @stylo.core/styles)))
+       (write! (stylo.core/get-styles {:pretty-print? false})
+               output-dir
+               file-name))
+     (assoc-path build-state file-name))))
+
+
+(defn reload-hook
+  {:shadow.build/stage :flush}
+  ([build-state]
+   (reload-hook build-state {:output-dir (str "target/" (name (:shadow.build/mode build-state)) "/public/css")
+                             :file-name "stylo.min.css"}))
+  ([build-state options]
+   (log/debug ::hook (str "Stylo styles: " (keys @stylo.core/styles)))
+   (let [{:keys [output-dir file-name]} options
+         output-dir (io/file output-dir)]
+     (when (seq @stylo.core/styles)
+       (if (.exists (io/file output-dir file-name))
+         (write! (stylo.core/get-stylo-styles)
+                 output-dir
+                 file-name
+                 true)
+         (write! (stylo.core/get-styles)
+                 output-dir
+                 file-name)))
+     (assoc-path build-state file-name))))


### PR DESCRIPTION
**Features:**
- Stylo styles dev and prod hooks
- Append styles to `stylo.css` in dev mode
- Compact styles in prod mode and write to `stylo.min.css`

`shadow-cljs.edn` example
```edn
{:builds {:web {:target :browser
                :dev {:build-hooks [(stylo.shadow-cljs/reload-hook)]}
                :release {:build-hooks [(stylo.shadow-cljs/hook {:output-dir "target/prod/public/css"
                                                                 :file-name "stylo.min.css"})]}}}}
```

**Problems:**
- Removing style rule does nothing in dev mode because the appended class does not override previously generated one:
```css
.my-ns-line-column {
  margin: 1rem;
  background: red;
}

/* later you removed [:m 1], so generated class will be */
.my-ns-line-column {
  background: red;
}

```
